### PR TITLE
Display sync progress during initial indexing

### DIFF
--- a/apps/backend/logic/system.js
+++ b/apps/backend/logic/system.js
@@ -3,7 +3,7 @@ const NodeError = require("models/errors.js").NodeError;
 
 async function getElectrumConnectionDetails() {
   try {
-    const port = constants.ELECTRUM_PORT;
+    const port = constants.ELECTRUM_PUBLIC_CONNECTION_PORT;
 
     const torAddress = constants.ELECTRUM_HIDDEN_SERVICE;
     const torConnectionString = `${torAddress}:${port}:t`;

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -11,7 +11,6 @@
     "postcoverage": "codecov"
   },
   "dependencies": {
-    "@lily-technologies/electrum-client": "^1.1.8",
     "bitcoind-rpc": "^0.9.1",
     "body-parser": "^1.18.2",
     "camelize-keys": "^1.0.0",
@@ -19,6 +18,7 @@
     "debug": "^2.6.1",
     "dotenv": "^8.2.0",
     "express": "^4.16.3",
+    "jayson": "^4.1.2",
     "module-alias": "^2.1.0",
     "morgan": "^1.9.0",
     "uuid": "^3.3.2",

--- a/apps/backend/services/fulcrum.js
+++ b/apps/backend/services/fulcrum.js
@@ -1,51 +1,65 @@
-const ElectrumClient = require("@lily-technologies/electrum-client");
+// const ElectrumClient = require("@lily-technologies/electrum-client");
+const jayson = require('jayson');
 const bitcoindService = require("services/bitcoind");
 
-const FULCRUM_HOST = process.env.FULCRUM_HOST || "0.0.0.0";
-const FULCRUM_PORT = parseInt(process.env.FULCRUM_PORT) || 50001;
-const rpcClient = new ElectrumClient(FULCRUM_PORT, FULCRUM_HOST, "tcp");
+const constants = require("utils/const.js");
 
-async function getVersion() {
-  // initElectrum() also requests the server version
-  // If tried to connect via the initElectrum(), the first time works,
-  // But henceforth Fulcrum will give error as it does not like 
-  // server version to be requested again in the same connection
-  // Hence connect() will be used instead.
-  await rpcClient.connect()
-
-  const versionInfo= await rpcClient.server_version("umbrel","1.4")
-  // versionInfo[0] comes in as fulcrum/0.9.4, so we parse
-  const version = versionInfo[0].substring(
-    versionInfo[0].indexOf("/") + 1
-  );
-  
-  // Close the connection, otherwise the next request for verion will give error 
-  await rpcClient.close()
-  
-  return version;
-}
-
-// This is a little hacky way of determining if fulcrum is sync'd to bitcoind
-// see https://github.com/romanz/electrs/pull/543#issuecomment-973078262
-async function syncPercent() {
-  // first, check if bitcoind isn't still IBD
-  const {
-    result: bitcoindResponse
-  } = await bitcoindService.getBlockChainInfo();
-  if (bitcoindResponse.initialblockdownload) {
-    return 0;
+// Fulcrum RPC details: https://github.com/cculianu/Fulcrum?tab=readme-ov-file#admin-script-fulcrumadmin
+class ElectrumClient {
+  constructor(host, port) {
+    this.client = new jayson.Client.tcp({
+      host,
+      port,
+      version: 2,
+      delimiter: '\n'
+    });
   }
 
-  // Similar to getversion() above.
-  await rpcClient.connect()
+  async request(method, params = []) {
+    return new Promise((resolve, reject) => {
+      this.client.request(method, params, (error, response) => {
+        if (error) return reject(error);
+        if (!response?.result) return reject(new Error('Invalid response'));
+        resolve(response.result);
+      });
+    });
+  }
+}
 
-  const {
-    height: fulcrumHeight
-  } = await rpcClient.blockchainHeaders_subscribe();
-  
-  await rpcClient.close()
-  
-  return (fulcrumHeight / bitcoindResponse.blocks) * 100;
+const electrumClient = new ElectrumClient(constants.ELECTRUM_HOST, constants.ELECTRUM_RPC_PORT);
+
+async function getVersion() {
+  // Returns version number from response format: "{name} {semver}"
+  // e.g., "Fulcrum 1.11.1" -> "1.11.1"
+  const info = await electrumClient.request('getinfo');
+  return info?.version?.split(' ')[1] ?? 'unknown';
+}
+
+async function syncPercent() {
+  try {
+    // If Bitcoin node is still syncing, we return -1 and render the "Waiting for Bitcoin Node to finish syncing..." message on the frontend
+    // This way, the sync percent is not calculated until the Bitcoin node is done syncing
+    const {
+      result: bitcoindResponse
+    } = await bitcoindService.getBlockChainInfo();
+    // TODO: comment out this console log for production
+    console.log('bitcoindResponse', bitcoindResponse);
+    if (bitcoindResponse.initialblockdownload) {
+      return -1;
+    }
+
+    const info = await electrumClient.request('getinfo');
+    // TODO: comment out this console log for production
+    console.log('fulcrum getinfo', info);
+    const dbHeight = info['height']; // Fulcrum height
+    const daemonHeight = bitcoindResponse.blocks; // Bitcoin node height
+
+    return Math.ceil((dbHeight / daemonHeight) * 100);
+  } catch (error) {
+    // If there's an error, which is likely due to a failed connection before ElectrumX is ready to accept connections on port 8000, we return -2
+    // and render "Connecting to ElectrumX server..." on the frontend
+    return -2;
+  }
 }
 
 module.exports = {

--- a/apps/backend/services/fulcrum.js
+++ b/apps/backend/services/fulcrum.js
@@ -1,6 +1,7 @@
 // const ElectrumClient = require("@lily-technologies/electrum-client");
 const jayson = require('jayson');
 const bitcoindService = require("services/bitcoind");
+const fs = require('fs');
 
 const constants = require("utils/const.js");
 
@@ -29,40 +30,96 @@ class ElectrumClient {
 const electrumClient = new ElectrumClient(constants.ELECTRUM_HOST, constants.ELECTRUM_RPC_PORT);
 
 async function getVersion() {
-  // Returns version number from response format: "{name} {semver}"
-  // e.g., "Fulcrum 1.11.1" -> "1.11.1"
-  const info = await electrumClient.request('getinfo');
-  return info?.version?.split(' ')[1] ?? 'unknown';
+  try {
+    // We first try querying the admin port
+    const info = await electrumClient.request('getinfo');
+    const version = info?.version?.split(' ')[1];
+    if (version) return version;
+
+    throw new Error('Invalid version from RPC');
+  } catch (error) {
+    // If RPC didn't return a valid version, fall back to log parsing
+    // Fulcrum Admin port doesn't start listening until the node is synced so for now we only use this if the RPC call fails
+    // We can remove this fallback if this GH Issue is resolved: https://github.com/cculianu/Fulcrum/issues/263
+    try {
+      const logs = fs.readFileSync('/fulcrum-logs/fulcrum.log', 'utf8');
+      const lines = logs.split('\n');
+      
+      const versionLine = lines.find(line => 
+        line.includes('Fulcrum') && line.includes('(Release')
+      ) || '';
+
+      const match = versionLine.match(/Fulcrum ([\d.]+)/);
+      return match ? match[1] : 'unknown';
+    } catch (logError) {
+      console.error('Error reading Fulcrum version:', logError);
+      return 'unknown';
+    }
+  }
 }
 
 async function syncPercent() {
   try {
-    // If Bitcoin node is still syncing, we return -1 and render the "Waiting for Bitcoin Node to finish syncing..." message on the frontend
-    // This way, the sync percent is not calculated until the Bitcoin node is done syncing
-    const {
-      result: bitcoindResponse
-    } = await bitcoindService.getBlockChainInfo();
-    // TODO: comment out this console log for production
-    console.log('bitcoindResponse', bitcoindResponse);
-    if (bitcoindResponse.initialblockdownload) {
-      return -1;
-    }
+    const bitcoindStatus = await getBitcoindStatus();
+    if (bitcoindStatus.initialblockdownload) return -1;
 
-    const info = await electrumClient.request('getinfo');
-    // TODO: comment out this console log for production
-    console.log('fulcrum getinfo', info);
-    const dbHeight = info['height']; // Fulcrum height
-    const daemonHeight = bitcoindResponse.blocks; // Bitcoin node height
-
-    return Math.ceil((dbHeight / daemonHeight) * 100);
+    const syncStatus = await getFulcrumSyncStatus(bitcoindStatus.blocks);
+    return syncStatus;
   } catch (error) {
-    // If there's an error, which is likely due to a failed connection before ElectrumX is ready to accept connections on port 8000, we return -2
-    // and render "Connecting to ElectrumX server..." on the frontend
+    console.error('Error getting Fulcrum sync percentage:', error);
+    // For -2 we render "Connecting to ElectrumX server..." on the frontend
     return -2;
   }
+}
+
+// Helper Functions:
+
+async function getBitcoindStatus() {
+  const { result: bitcoindResponse } = await bitcoindService.getBlockChainInfo();
+  return bitcoindResponse;
+}
+
+async function getFulcrumSyncStatus(daemonHeight) {
+  try {
+    // We first try querying the admin port
+    return await getRPCSyncStatus(daemonHeight);
+  } catch (error) {
+    // If the admin port is not ready, we fall back to parsing the logs
+    return getLogSyncStatus();
+  }
+}
+
+// Get sync status via RPC
+async function getRPCSyncStatus(daemonHeight) {
+  const info = await electrumClient.request('getinfo');
+  console.log('fulcrum height', info.height);
+  const dbHeight = info['height'];
+  return Math.ceil((dbHeight / daemonHeight) * 100);
+}
+
+// Get sync status via log parsing
+async function getLogSyncStatus() {
+  const logs = fs.readFileSync('/fulcrum-logs/fulcrum.log', 'utf8');
+  
+  const lines = logs.split('\n').reverse();
+  const latestLine = lines.find(line => 
+    /<Controller> Processed height: (\d+), ([\d.]+)%/.test(line)
+  ) || '';
+
+  console.log('latest sync status from logs', latestLine);
+  // example
+  // [2024-11-16 05:21:59.953] <Controller> Processed height: 1000, 10.0%, 4119.3 blocks/
+
+  const percentageMatch = latestLine.match(/(\d+), ([\d.]+)%/);
+  if (!percentageMatch) throw new Error('No sync percentage found in logs');
+  
+  const percentage = percentageMatch[2];
+  console.log('sync percentage from logs', percentage);
+  return parseFloat(percentage);
 }
 
 module.exports = {
   getVersion,
   syncPercent
 };
+

--- a/apps/backend/utils/const.js
+++ b/apps/backend/utils/const.js
@@ -3,10 +3,11 @@ module.exports = {
   REQUEST_CORRELATION_NAMESPACE_KEY: "umbrel-fulcrum-request",
   REQUEST_CORRELATION_ID_KEY: "reqId",
 
-  ELECTRUM_HIDDEN_SERVICE:
-    process.env.ELECTRUM_HIDDEN_SERVICE || "/var/lib/tor/electrum/hostname",
+  ELECTRUM_HIDDEN_SERVICE: process.env.ELECTRUM_HIDDEN_SERVICE || "/var/lib/tor/electrum/hostname",
 
   ELECTRUM_LOCAL_SERVICE: process.env.ELECTRUM_LOCAL_SERVICE || "umbrel.local",
 
-  ELECTRUM_PORT: process.env.ELECTRUM_PORT || 50001,
+  ELECTRUM_HOST: process.env.ELECTRUM_HOST || "0.0.0.0",
+  ELECTRUM_PUBLIC_CONNECTION_PORT: process.env.ELECTRUM_PUBLIC_CONNECTION_PORT || 50001,
+  ELECTRUM_RPC_PORT: process.env.ELECTRUM_RPC_PORT || 8000,
 };

--- a/apps/frontend/src/components/ConnectionInformation.vue
+++ b/apps/frontend/src/components/ConnectionInformation.vue
@@ -1,8 +1,11 @@
 <template>
   <div class="mt-16">
-    <p class="mb-8 text-neutral-900 dark:text-neutral-300 text-lg">
+    <p class="mb-1 text-neutral-900 dark:text-neutral-300 text-lg">
       Use the following details to connect your wallet or application to
       Fulcrum.
+    </p>
+    <p class="mb-8 text-sm text-neutral-600 dark:text-neutral-400">
+      Connections will only be available once Fulcrum has completed syncing.
     </p>
     <div class="flex flex-col md:grid md:grid-cols-12 md:gap-8">
       <div

--- a/apps/frontend/src/store/modules/fulcrum.js
+++ b/apps/frontend/src/store/modules/fulcrum.js
@@ -8,7 +8,10 @@ const state = () => ({
     port: "",
     connectionString: "",
   },
-  syncPercent: 0,
+  // -1: Bitcoin node is still syncing
+  // -2: Fulcrum connection failed
+  // >= 0: Fulcrum sync percent
+  syncPercent: -2,
 });
 
 // Functions to update the state directly

--- a/apps/frontend/src/views/Home.vue
+++ b/apps/frontend/src/views/Home.vue
@@ -32,23 +32,27 @@
 
     <div class="flex justify-end mb-2">
       <h3 class="font-semibold mb-0 text-gray-800 dark:text-gray-200">
-        <span v-if="syncPercent > 0">
-          <span> {{ syncPercent >= 99.99 ? 100 : Number(syncPercent).toFixed(0) }}%</span>
+        <!-- Case 1: Bitcoin Node still syncing -->
+        <span v-if="syncPercent === -1" class="animate-pulse">
+          Waiting for Bitcoin Node to finish syncing...
+        </span>
+        <!-- Case 2: Normal sync progress -->
+        <span v-else-if="syncPercent >= 0">
+          <span>{{ syncPercent >= 99.99 ? 100 : Number(syncPercent).toFixed(0) }}%</span>
           <span class="align-self-end ml-1">Synchronized</span>
         </span>
+        <!-- Case 3: Waiting for Fulcrum response -->
         <span v-else class="animate-pulse">
-          Fulcrum is currently indexing, which may take some time...
+          Connecting to Fulcrum server...
         </span>
       </h3>
     </div>
     <progress-bar
-      :percentage="syncPercent"
+      :percentage="progressBarPercentage"
       colorClass="bg-green-400"
       class="h-2"
     ></progress-bar>
-
     <connection-information />
-
   </div>
 </template>
 
@@ -70,6 +74,10 @@ export default {
         return state.fulcrum.syncPercent;
       },
     }),
+    progressBarPercentage() {
+      // Clamp the value between 0 and 100 so that -1 and -2 are not displayed as 100%
+      return Math.max(0, Math.min(100, this.syncPercent));
+    }
   },
   methods:  {
     fetchData() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: "3.7"
 services:
   app:
     build: .
+    depends_on:
+      - fulcrum
     command: npm run dev:backend
     restart: on-failure
     environment:
@@ -15,17 +17,17 @@ services:
     ports:
       - "3006:3006"
   fulcrum:
-    image: getumbrel/fulcrum:v0.9.4@sha256:b1590ac6cfb0e5b481c6a7af7f0626d76cbb91c63702b0f5c47e2829e9c37997
+    image: cculianu/fulcrum:v1.11.1@sha256:70f06b93ab5863997992d4b4508312fe81ce576017e16ecc7e69c7d38165bdf2
     environment:
-      FULCRUM_LOG_FILTERS: "INFO"
-      FULCRUM_NETWORK: "regtest"
-      FULCRUM_DAEMON_RPC_ADDR: "bitcoind:18443"
-      FULCRUM_DAEMON_P2P_ADDR: "bitcoind:18444"
-      FULCRUM_ELECTRUM_RPC_ADDR: "0.0.0.0:50001"
-      FULCRUM_SERVER_BANNER: "Umbrel Fulcrum"
-      FULCRUM_COOKIE_FILE: "/bitcoin/regtest/.cookie"
+      TCP: 0.0.0.0:50001
+      ADMIN: 0.0.0.0:8000
+      BITCOIND: bitcoind:18443
+      RPCUSER: umbrel
+      RPCPASSWORD: moneyprintergobrrr
+      PEERING: "false"
+      ANNOUNCE: "false"
+    command: Fulcrum _ENV_
     volumes:
-      - ${PWD}/data/bitcoin:/bitcoin
       - ${PWD}/data/fulcrum:/data
     restart: always
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       RPC_PORT: 18443
     ports:
       - "3006:3006"
+    volumes:
+      - ${PWD}/data/fulcrum-logs:/fulcrum-logs
   fulcrum:
     image: cculianu/fulcrum:v1.11.1@sha256:70f06b93ab5863997992d4b4508312fe81ce576017e16ecc7e69c7d38165bdf2
     environment:
@@ -28,15 +30,16 @@ services:
       RPCPASSWORD: moneyprintergobrrr
       PEERING: "false"
       ANNOUNCE: "false"
-    command: Fulcrum _ENV_
+    command: sh -c 'Fulcrum -D /data _ENV_ 2>&1 | tee /logs/fulcrum.log'
     volumes:
       - ${PWD}/data/fulcrum:/data
+      - ${PWD}/data/fulcrum-logs:/logs
     restart: always
     ports:
       - "50001:50001"
   bitcoind:
     image: lncm/bitcoind:v22.0@sha256:37a1adb29b3abc9f972f0d981f45e41e5fca2e22816a023faa9fdc0084aa4507
-    command: -regtest -rpcbind=0.0.0.0 -rpcallowip=0.0.0.0/0 -rpcauth=umbrel:5071d8b3ba93e53e414446ff9f1b7d7b$$375e9731abd2cd2c2c44d2327ec19f4f2644256fdeaf4fc5229bf98b778aafec
+    command: -regtest -rpcbind=0.0.0.0 -rpcallowip=0.0.0.0/0 -rpcauth=umbrel:5071d8b3ba93e53e414446ff9f1b7d7b$$375e9731abd2cd2c2c44d2327ec19f4f2644256fdeaf4fc5229bf98b778aafec -txindex=1
     volumes:
       - ${PWD}/data/bitcoin:/data/.bitcoin
     restart: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,12 @@ services:
     environment:
       ELECTRUM_HIDDEN_SERVICE: "somehiddenserviceurl.onion"
       ELECTRUM_LOCAL_SERVICE: "umbrel.local"
-      FULCRUM_HOST: fulcrum
+      ELECTRUM_HOST: fulcrum
+      ELECTRUM_PUBLIC_CONNECTION_PORT: 50001
       BITCOIN_HOST: bitcoind
       RPC_USER: umbrel
       RPC_PASSWORD: moneyprintergobrrr
+      RPC_PORT: 18443
     ports:
       - "3006:3006"
   fulcrum:
@@ -38,5 +40,3 @@ services:
     volumes:
       - ${PWD}/data/bitcoin:/data/.bitcoin
     restart: on-failure
-    ports:
-      - "18443:18443"


### PR DESCRIPTION
Hey @sahilph. We're getting ready to have Fulcrum (and a new ElectrumX app) be hot swappable with Electrs on umbrelOS.

In preparation, I've taken a look at the issue of not being able to get sync progress while fulcrum is in the middle of it's initial index. I have a working solution with this PR.

This is fully working and has been tested on umbrelOS so please feel free to just merge it. I also updated the compose file in this repo so that the dev environment works (e.g., run `docker-compose up -d` to get things running on regtest. You can then mine blocks in the bitcoind container with `bitcoin-cli -regtest generatetoaddress 1 "bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw"`).

If you'd be able to merge this and build/push a new Docker image, then I will  update the files at https://github.com/getumbrel/umbrel-apps/tree/master/fulcrum in a couple days with some changes that are needed to get things working properly in the app store (requires some env var changes, pre-start changes, and a new manifest key to allow it to be hot-swappable).

------------------------
**Changes:**
TL/DR; I've hacked it a bit so that the frontend is parsing the fulcrum logs to get sync percent while fulcrum isn't listening on it's admin port (8000).

Two main changes:

1) Fulcrum has an admin port that we can query for info instead of the main tcp port that we are currently using. The new ElectrumX app I have working is doing something similar, so I have done the same thing here for easy maintainability. 
Unfortunately though, unlike ElectrumX, fulcrum doesn't listen on the admin port until after it has completed the initial index. So this alone is not enough for us. I have opened an issue on fulcrum's repo asking if we can listen on the admin port right away, similar to how ElectrumX functions: https://github.com/cculianu/Fulcrum/issues/263. If this is implemented then we can remove the log-parsing hack described below.

2) If the admin port is closed, we fall back to parsing the fulcrum logs to get sync percent. We always try the admin port first each time we poll from the frontend. Hopefully fulcrum devs can change things so that querying the admin port is possible during initial indexing and we can remove this hack.