### PR TITLE
Render database corruption message in UI

### DIFF
--- a/apps/frontend/src/store/modules/fulcrum.js
+++ b/apps/frontend/src/store/modules/fulcrum.js
@@ -10,6 +10,7 @@ const state = () => ({
   },
   // -1: Bitcoin node is still syncing
   // -2: Fulcrum connection failed
+  // -3: Fulcrum database is corrupted
   // >= 0: Fulcrum sync percent
   syncPercent: -2,
 });

--- a/apps/frontend/src/views/Home.vue
+++ b/apps/frontend/src/views/Home.vue
@@ -41,7 +41,11 @@
           <span>{{ syncPercent >= 99.99 ? 100 : Number(syncPercent).toFixed(0) }}%</span>
           <span class="align-self-end ml-1">Synchronized</span>
         </span>
-        <!-- Case 3: Waiting for Fulcrum response -->
+        <!-- Case 3: Fatal error in Fulcrum -->
+        <span v-else-if="syncPercent === -3" class="text-red-500">
+          Database error - Please reinstall app or delete database and restart app to resync
+        </span>
+        <!-- Case 4: Waiting for Fulcrum response -->
         <span v-else class="animate-pulse">
           Connecting to Fulcrum server...
         </span>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       - ${PWD}/data/fulcrum-logs:/fulcrum-logs
   fulcrum:
     image: cculianu/fulcrum:v1.11.1@sha256:70f06b93ab5863997992d4b4508312fe81ce576017e16ecc7e69c7d38165bdf2
+    init: true
+    stop_grace_period: 1m
     environment:
       TCP: 0.0.0.0:50001
       ADMIN: 0.0.0.0:8000


### PR DESCRIPTION
This PR renders a database corruption message in the UI so users can take action should it occur.

<img width="947" alt="Screenshot 2024-11-26 at 11 31 38 AM" src="https://github.com/user-attachments/assets/bc8164b3-3627-4075-bb49-a82bc0a6ea8a">

I've also added the following to the fulcrum service to improve the fulcrum container's shutdown handling
```yaml
init: true
stop_grace_period: 1m
```

I've tested restarting the app multiple times in the middle of indexing and this should solve at least some of the corruption issues; however, this is probably something that needs to be handled in https://github.com/cculianu/Fulcrum